### PR TITLE
Tweaked article linking

### DIFF
--- a/main.js
+++ b/main.js
@@ -79,7 +79,7 @@ function cmd_help(msg, args) {
 }
 
 function cmd_say(msg, args) {
-	if ( msg.member != null && msg.member.roles.find('name', 'Administrator') ) {
+	if ( msg.author.id == msg.guild.ownerID || msg.author.id == process.env.owner || ( msg.member != null && msg.member.roles.find('name', 'Administrator') ) ) {
 		if ( args[0] == 'alarm' ) {
 			msg.channel.send(':rotating_light: **' + args.slice(1).join(' ') + '** :rotating_light:');
 		} else {

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 const Discord = require('discord.js');
+var request = require('request');
 
 var client = new Discord.Client();
 
@@ -13,8 +14,15 @@ client.on('ready', () => {
 
 
 var cmdmap = {
+	hilfe: cmd_help,
+	help: cmd_help,
+	befehl: cmd_befehl2,
+	command: cmd_befehl2,
+	cmd: cmd_befehl2,
 	say: cmd_say,
 	test: cmd_test,
+	seite: cmd_seite,
+	page: cmd_seite,
 	technik: cmd_technik,
 	en: cmd_en,
 	uwmc: cmd_uwmc,
@@ -25,8 +33,53 @@ var cmdmap = {
 	pause: cmd_pause
 }
 
+function cmd_help(msg, args) {
+	var cmds = [
+		{ cmd: '<Suchbegriff>', desc: 'Ich antworte mit einem Link auf einen passenden Artikel im Minecraft Wiki', unsearchable: true },
+		{ cmd: '/<Minecraft-Befehl>', desc: 'Ich antworte mit der Syntax des angegebenen Minecraft-Befehls und einem Link auf den Artikel zu diesem Befehl im Minecraft Wiki', unsearchable: true },
+		{ cmd: 'befehl <Minecraft-Befehl>', desc: 'Ich antworte mit der Syntax des angegebenen Minecraft-Befehls und einem Link auf den Artikel zu diesem Befehl im Minecraft Wiki', hide: true },
+		{ cmd: 'command <Minecraft-Befehl>', desc: 'Ich antworte mit der Syntax des angegebenen Minecraft-Befehls und einem Link auf den Artikel zu diesem Befehl im Minecraft Wiki', hide: true },
+		{ cmd: 'cmd <Minecraft-Befehl>', desc: 'Ich antworte mit der Syntax des angegebenen Minecraft-Befehls und einem Link auf den Artikel zu diesem Befehl im Minecraft Wiki', hide: true },
+		{ cmd: 'hilfe', 'Liste alle Befehle auf' },
+		{ cmd: 'hilfe [<Befehl>]', desc: 'Frage mich, wie ein Befehl funktioniert' },
+		{ cmd: 'help', 'Liste alle Befehle auf', hide: true },
+		{ cmd: 'help [<Befehl>]', desc: 'Frage mich, wie ein Befehl funktioniert', hide: true },
+		{ cmd: 'test', desc: 'Wenn ich gerade aktiv bin, werde ich antworten! Sonst nicht.' },
+		{ cmd: 'seite <Seitenname>', desc: 'Ich antworte mit einem Link zu der angegebenen Seite im Minecraft Wiki' },
+		{ cmd: 'page <Seitenname>', desc: 'Ich antworte mit einem Link zu der angegebenen Seite im Minecraft Wiki', hide: true },
+		{ cmd: 'technik <Seitenname>', desc: 'Ich antworte mit einem Link zu der angegebenen Seite im Technik Wiki' },
+		{ cmd: 'en <Seitenname>', desc: 'Ich antworte mit einem Link zu der angegebenen Seite im englischen Minecraft Wiki' },
+		{ cmd: 'uwmc <Seitenname>', desc: 'Ich antworte mit einem Link zu der angegebenen Seite im Unlimitedworld-Forum' },
+		{ cmd: 'invite', desc: 'Ich antworte mit dem Invite-Link für diesen Server' },
+		{ cmd: 'suche <Suchbegriff>', desc: 'Ich antworte mit einem Link auf die Suchseite zu diesem Begriff im Minecraft Wiki.' }
+		{ cmd: 'search <Suchbegriff>', desc: 'Ich antworte mit einem Link auf die Suchseite zu diesem Begriff im Minecraft Wiki.', hide: true }
+	]
+	
+	if ( args.length ) {
+		var cmdlist = ''
+		for ( var i = 0; i < cmds.length; i++ ) {
+			if ( cmds[i].split(' ')[0].equals( args[0].toLowerCase() ) && !cmds[i].unsearchable ) {
+				cmdlist += '🔹 `!wiki ' + cmds[i].cmd + '\n\t' + cmds[i].desc + '\n';
+			}
+		}
+		
+		if ( cmdlist.equals( '' ) ) msg.react('❓');
+		else msg.channel.send(cmdlist);
+	}	
+	else {
+		var cmdlist = 'Du willst also wissen, was ich so drauf habe? Hier ist eine Liste aller Befehle, die ich verstehe:\n';
+		for ( var i = 0; i < cmds.length; i++ ) {
+			if ( !cmds[i].hide ) {
+				cmdlist += '🔹 `!wiki ' + cmds[i].cmd + '\n\t' + cmds[i].desc + '\n';
+			}
+		}
+		
+		msg.channel.send(cmdlist);
+	}
+}
+
 function cmd_say(msg, args) {
-	if ( msg.author.id == msg.guild.ownerID || msg.author.id == process.env.owner ) {
+	if ( msg.member != null && msg.member.roles.find('name', 'Administrator') ) {
 		if ( args[0] == 'alarm' ) {
 			msg.channel.send(':rotating_light: **' + args.slice(1).join(' ') + '** :rotating_light:');
 		} else {
@@ -34,9 +87,7 @@ function cmd_say(msg, args) {
 		}
 		msg.delete();
 	} else {
-		var space = '';
-		if (args.length) space = '_';
-		msg.channel.send('https://minecraft-de.gamepedia.com/say' + space + args.join('_'));
+		msg.react('❌')
 	}
 }
 
@@ -69,7 +120,11 @@ function cmd_test(msg, args) {
 		msg.reply('ich mache gerade eine Pause.');
 		console.log('Dies ist ein Test: Pausiert!');
 	}
+
+function cmd_seite(msg, args) {
+	msg.channel.send('https://minecraft-de.gamepedia.com/' + args.join('_'));
 }
+	}
 
 function cmd_technik(msg, args) {
 	msg.channel.send('https://minecraft-technik.gamepedia.com/' + args.join('_'));
@@ -456,15 +511,19 @@ var aliase = {
 }
 
 function cmd_befehl(msg, befehl, args) {
-	if ( befehl in befehle ) {
-		msg.channel.send('```markdown\n' + befehle[befehl].join('\n') + '\n```\nhttps://minecraft-de.gamepedia.com/Befehl/' + befehl);
-	} else if ( befehl in aliase ) {
-		cmd_befehl(msg, aliase[befehl], args);
-	} else {
-		var space = '';
-		if (args.length) space = '_';
-		msg.channel.send('https://minecraft-de.gamepedia.com//' + befehl + space + args.join('_'));
+	var aliasCmd = ( befehl in aliase ) ? aliase[befehl] : befehl;
+	
+	if ( aliasCmd in befehle ) {
+		var cmdSyntax = befehle[aliasCmd].join( '\n' ).replace( '/' + aliasCmd, '/' + befehl );
+		msg.channel.send('```markdown\n' + cmdSyntax + '\n```\nhttps://minecraft-de.gamepedia.com/Befehl/' + aliasCmd);
 	}
+	else {
+		msg.react('❓');
+	}
+}
+
+function cmd_befehl2(msg, args) {
+	cmd_befehl(msg, args[0], args.slice(1));
 }
 
 
@@ -472,8 +531,8 @@ client.on('message', msg => {
 	var cont = msg.content;
 	var author = msg.member;
 	var channel = msg.channel;
-	if ( channel.type == 'text' && author.id != client.user.id && cont.startsWith(process.env.prefix) ) {
-		var invoke = cont.split(' ')[1];
+	if ( channel.type == 'text' && author.id != client.user.id && cont.toLowerCase().startsWith(process.env.prefix) ) {
+		var invoke = cont.split(' ')[1].toLowerCase();
 		var args = cont.split(' ').slice(2);
 		console.log(invoke + ' - ' + args);
 		if ( !pause ) {
@@ -482,9 +541,35 @@ client.on('message', msg => {
 			} else if ( invoke.startsWith('/') ) {
 				cmd_befehl(msg, invoke.substr(1), args);
 			} else {
-				var space = '';
-				if (args.length) space = '_';
-				channel.send('https://minecraft-de.gamepedia.com/' + invoke + space + args.join('_'));
+				var title = cont.split(' ')[1]. + (args.length ? '_' : '') + args.join('_');
+				
+				if ( title.contains( '#' ) ) channel.send( 'https://minecraft-de.gamepedia.com/' + title );
+				else {
+					var hourglass;
+					msg.react('⏳').then( function( reaction ) {
+						hourglass = reaction;
+					} ).catch( console.log ).finally( function() {
+						request( {
+							uri: 'https://minecraft-de.gamepedia.com/api.php?action=query&format=json&list=search&srsearch=' + title + '&srlimit=1',
+							json: true
+						}, function( error, response, body ) {
+							if ( error || !response || !body ) {
+								console.log( 'Error while getting search results: ' + error );
+								channel.send( 'https://minecraft-de.gamepedia.com/' + title );
+							}
+							else {
+								if ( body.query.searchinfo.totalhits == 0 ) {
+									channel.send( 'https://minecraft-de.gamepedia.com/' + title );
+								}
+								else {
+									channel.send( 'https://minecraft-de.gamepedia.com/' + encodeURIComponent( body.query.search[0].title ) );
+								}
+							}
+							
+							if ( hourglass != undefined ) hourglass.remove();
+						} );
+					} );
+				}
 			}
 		} else if ( pause && author.id == process.env.owner && ( invoke == "pause" || invoke == "stop" || invoke == "say" || invoke == "test" ) ) {
 			cmdmap[invoke](msg, args);

--- a/main.js
+++ b/main.js
@@ -548,7 +548,7 @@ client.on('message', msg => {
 					msg.react('⏳').then( function( reaction ) {
 						hourglass = reaction;
 						request( {
-							uri: 'https://minecraft-de.gamepedia.com/api.php?action=query&format=json&list=search&srsearch=' + title + '&srlimit=2',
+							uri: 'https://minecraft-de.gamepedia.com/api.php?action=query&format=json&list=search&srsearch=' + title + '&srlimit=1',
 							json: true
 						}, function( error, response, body ) {
 							if ( error || !response || !body ) {

--- a/main.js
+++ b/main.js
@@ -58,12 +58,12 @@ function cmd_help(msg, args) {
 	if ( args.length ) {
 		var cmdlist = ''
 		for ( var i = 0; i < cmds.length; i++ ) {
-			if ( cmds[i].cmd.split(' ')[0].equals( args[0].toLowerCase() ) && !cmds[i].unsearchable ) {
+			if ( cmds[i].cmd.split(' ')[0] === args[0].toLowerCase() && !cmds[i].unsearchable ) {
 				cmdlist += '🔹 `!wiki ' + cmds[i].cmd + '`\n\t' + cmds[i].desc + '\n';
 			}
 		}
 		
-		if ( cmdlist.equals( '' ) ) msg.react('❓');
+		if ( cmdlist == '' ) msg.react('❓');
 		else msg.channel.send(cmdlist);
 	}	
 	else {
@@ -323,7 +323,6 @@ var befehle = {
 				],
 	'list':			[
 					'/list'
-				],
 	'locate':		[
 					'/locate <Bauwerk>'
 				],
@@ -549,7 +548,7 @@ client.on('message', msg => {
 					msg.react('⏳').then( function( reaction ) {
 						hourglass = reaction;
 						request( {
-							uri: 'https://minecraft-de.gamepedia.com/api.php?action=query&format=json&list=search&srsearch=' + title + '&srlimit=1',
+							uri: 'https://minecraft-de.gamepedia.com/api.php?action=query&format=json&list=search&srsearch=' + title + '&srlimit=2',
 							json: true
 						}, function( error, response, body ) {
 							if ( error || !response || !body ) {

--- a/main.js
+++ b/main.js
@@ -59,7 +59,7 @@ function cmd_help(msg, args) {
 		var cmdlist = ''
 		for ( var i = 0; i < cmds.length; i++ ) {
 			if ( cmds[i].cmd.split(' ')[0] === args[0].toLowerCase() && !cmds[i].unsearchable ) {
-				cmdlist += '🔹 `!wiki ' + cmds[i].cmd + '`\n\t' + cmds[i].desc + '\n';
+				cmdlist += '🔹 `' + config.prefix + cmds[i].cmd + '`\n\t' + cmds[i].desc + '\n';
 			}
 		}
 		
@@ -70,7 +70,7 @@ function cmd_help(msg, args) {
 		var cmdlist = 'Du willst also wissen, was ich so drauf habe? Hier ist eine Liste aller Befehle, die ich verstehe:\n';
 		for ( var i = 0; i < cmds.length; i++ ) {
 			if ( !cmds[i].hide ) {
-				cmdlist += '🔹 `!wiki ' + cmds[i].cmd + '\n\t' + cmds[i].desc + '\n';
+				cmdlist += '🔹 `' + config.prefix + cmds[i].cmd + '\n\t' + cmds[i].desc + '\n';
 			}
 		}
 		
@@ -79,7 +79,7 @@ function cmd_help(msg, args) {
 }
 
 function cmd_say(msg, args) {
-	if ( msg.author.id == msg.guild.ownerID || msg.author.id == process.env.owner || ( msg.member != null && msg.member.roles.find('name', 'Administrator') ) ) {
+	if ( msg.author.id == msg.guild.ownerID || msg.author.id == process.env.owner || msg.member.roles.find('name', 'Administrator') ) {
 		if ( args[0] == 'alarm' ) {
 			msg.channel.send(':rotating_light: **' + args.slice(1).join(' ') + '** :rotating_light:');
 		} else {
@@ -139,7 +139,7 @@ function cmd_uwmc(msg, args) {
 }
 
 function cmd_invite(msg, args) {
-	if ( args[0].toLowerCase() == 'minecraft' ) {
+	if ( args.length && args[0].toLowerCase() == 'minecraft' ) {
 		msg.reply('hier findest du den offiziellen Minecraft-Discord:\nhttps://discord.gg/minecraft');
 	} else {
 		msg.reply('du kannst andere Nutzer mit diesem Link einladen:\nhttps://discord.gg/F75vfpd');
@@ -277,32 +277,34 @@ var befehle = {
 					'/enchant <Selektor> <Verzauberungs-ID> [<Stufe>]'
 				],
 	'execute':		[
-					'/execute align <Achsen> <execute-Unterbefehl>',
-					'/execute anchored (eyes|feet) <execute-Unterbefehl>',
-					'/execute as <Objekt> <execute-Unterbefehl>',
-					'/execute at <Objekt> <execute-Unterbefehl>',
-					'/execute facing <Koordinaten> <execute-Unterbefehl>',
-					'/execute facing entity <Objekt> <execute-Unterbefehl>',
-					'/execute if block <Koordinaten> <Block> <execute-Unterbefehl>',
-					'/execute if blocks <von-Koordinaten> <bis-Koordinaten> <Vergleichskoordinaten> <Block> <execute-Unterbefehl>',
-					'/execute if entity <Objekt> <execute-Unterbefehl>',
-					'/execute if score <Objekt> <Ziel> (<|<=|=|>|>=) <Objekt> <Ziel> <execute-Unterbefehl>',
-					'/execute if score <Objekt> <Ziel> matches <Bereich> <execute-Unterbefehl>',
-					'/execute in (overworld|the_end|the_nether) <execute-Unterbefehl>',
-					'/execute positioned <Koordinaten> <execute-Unterbefehl>',
-					'/execute positioned as <Objekt> <execute-Unterbefehl>',
-					'/execute rotated <Rotation> <execute-Unterbefehl>',
-					'/execute rotated as <Objekt> <execute-Unterbefehl>',
-					'/execute run <Befehl>',
-					'/execute store (result|success) block <Koordinaten> <Pfad> <Typ> <Skalierung> <execute-Unterbefehl>',
-					'/execute store (result|success) bossbar <Datenwert> (max|value) <Pfad> <Typ> <Skalierung> <execute-Unterbefehl>',
-					'/execute store (result|success) entity <Objekt> <Pfad> <Typ> <Skalierung> <execute-Unterbefehl>',
-					'/execute store (result|success) score <Objekt> <Ziel> <execute-Unterbefehl>',
-					'/execute unless block <Koordinaten> <Block> <execute-Unterbefehl>',
-					'/execute unless blocks <von-Koordinaten> <bis-Koordinaten> <Vergleichskoordinaten> <Block> <execute-Unterbefehl>',
-					'/execute unless entity <Objekt> <execute-Unterbefehl>',
-					'/execute unless score <Objekt> <Ziel> (<|<=|=|>|>=) <Objekt> <Ziel> <execute-Unterbefehl>',
-					'/execute unless score <Objekt> <Ziel> matches <Bereich> <execute-Unterbefehl>'
+					'/execute <Unterbefehl>',
+					'\nUnterbefehle:\n=============',
+					'run <Befehl>',
+					'align <Achsen> <Unterbefehl>',
+					'anchored (eyes|feet) <Unterbefehl>',
+					'as <Selektor> <Unterbefehl>',
+					'at <Selektor> <Unterbefehl>',
+					'facing <x> <y> <z> <Unterbefehl>',
+					'facing entity <Selektor> <Unterbefehl>',
+					'if block <x> <y> <z> <Block> <Unterbefehl>',
+					'if blocks <x1> <y1> <z1> <x2> <y2> <z2> <x> <y> <z> <Block> <Unterbefehl>',
+					'if entity <Selektor> <Unterbefehl>',
+					'if score <Selektor> <Ziel> (<|<=|=|>|>=) <Selektor> <Ziel> <Unterbefehl>',
+					'if score <Selektor> <Ziel> matches <Punktebereich> <Unterbefehl>',
+					'in <Dimension> <Unterbefehl>',
+					'positioned <x> <y> <z> <Unterbefehl>',
+					'positioned as <Selektor> <Unterbefehl>',
+					'rotated <Rotation> <Unterbefehl>',
+					'rotated as <Selektor> <Unterbefehl>',
+					'store (result|success) block <x> <y> <z> <Pfad> <Typ> <Skalierung> <Unterbefehl>',
+					'store (result|success) bossbar <Name> (max|value) <Pfad> <Typ> <Skalierung> <Unterbefehl>',
+					'store (result|success) entity <Selektor> <Pfad> <Typ> <Skalierung> <Unterbefehl>',
+					'store (result|success) score <Selektor> <Ziel> <Unterbefehl>',
+					'unless block <x> <y> <z> <Block> <Unterbefehl>',
+					'unless blocks <x1> <y1> <z1> <x2> <y2> <z2> <x> <y> <z> <Block> <Unterbefehl>',
+					'unless entity <Selektor> <Unterbefehl>',
+					'unless score <Selektor> <Ziel> <Operator> <Selektor> <Ziel> <Unterbefehl>',
+					'unless score <Selektor> <Ziel> matches <Punktebereich> <Unterbefehl>'
 				],
 	'experience':		[
 					'/experience add <Selektor> <Menge>',
@@ -548,7 +550,12 @@ function cmd_befehl(msg, befehl, args) {
 }
 
 function cmd_befehl2(msg, args) {
-	cmd_befehl(msg, args[0], args.slice(1));
+	if ( args[0].startsWith('/') ) {
+		cmd_befehl(msg, args[0].substr(1), args.slice(1));
+	}
+	else {
+		cmd_befehl(msg, args[0], args.slice(1));
+	}
 }
 
 

--- a/main.js
+++ b/main.js
@@ -58,7 +58,7 @@ function cmd_help(msg, args) {
 	if ( args.length ) {
 		var cmdlist = ''
 		for ( var i = 0; i < cmds.length; i++ ) {
-			if ( cmds[i].split(' ')[0].equals( args[0].toLowerCase() ) && !cmds[i].unsearchable ) {
+			if ( cmds[i].cmd.split(' ')[0].equals( args[0].toLowerCase() ) && !cmds[i].unsearchable ) {
 				cmdlist += '🔹 `!wiki ' + cmds[i].cmd + '`\n\t' + cmds[i].desc + '\n';
 			}
 		}
@@ -558,10 +558,14 @@ client.on('message', msg => {
 							}
 							else {
 								if ( body.query.searchinfo.totalhits == 0 ) {
-									channel.send( 'https://minecraft-de.gamepedia.com/' + title );
+									msg.react('🤷');
+								}
+								else if ( body.query.searchinfo.totalhits == 1 ) {
+									channel.send( 'https://minecraft-de.gamepedia.com/' + encodeURIComponent( body.query.search[0].title.replace( ' ', '_' ) ) );
 								}
 								else {
-									channel.send( 'https://minecraft-de.gamepedia.com/' + encodeURIComponent( body.query.search[0].title ) );
+									channel.send( 'https://minecraft-de.gamepedia.com/' + encodeURIComponent( body.query.search[0].title.replace( ' ', '_' ) )
+										     + '\nNicht das richtige Ergebnis? Nutze `!wiki suche ' + title.replace( '_', ' ' ) + '` für eine Liste mit allen Treffern!' );
 								}
 							}
 							

--- a/main.js
+++ b/main.js
@@ -323,6 +323,7 @@ var befehle = {
 				],
 	'list':			[
 					'/list'
+				],
 	'locate':		[
 					'/locate <Bauwerk>'
 				],

--- a/main.js
+++ b/main.js
@@ -541,7 +541,7 @@ client.on('message', msg => {
 			} else if ( invoke.startsWith('/') ) {
 				cmd_befehl(msg, invoke.substr(1), args);
 			} else {
-				var title = cont.split(' ')[1]. + (args.length ? '_' : '') + args.join('_');
+				var title = cont.split(' ')[1] + (args.length ? '_' : '') + args.join('_');
 				
 				if ( title.contains( '#' ) ) channel.send( 'https://minecraft-de.gamepedia.com/' + title );
 				else {

--- a/main.js
+++ b/main.js
@@ -560,10 +560,10 @@ client.on('message', msg => {
 									msg.react('🤷');
 								}
 								else if ( body.query.searchinfo.totalhits == 1 ) {
-									channel.send( 'https://minecraft-de.gamepedia.com/' + encodeURIComponent( body.query.search[0].title.replace( ' ', '_' ) ) );
+									channel.send( 'https://minecraft-de.gamepedia.com/' + encodeURI( body.query.search[0].title.replace( ' ', '_' ) ) );
 								}
 								else {
-									channel.send( 'https://minecraft-de.gamepedia.com/' + encodeURIComponent( body.query.search[0].title.replace( ' ', '_' ) )
+									channel.send( 'https://minecraft-de.gamepedia.com/' + encodeURI( body.query.search[0].title.replace( ' ', '_' ) )
 										     + '\nNicht das richtige Ergebnis? Nutze `!wiki suche ' + title.replace( '_', ' ' ) + '` für eine Liste mit allen Treffern!' );
 								}
 							}

--- a/main.js
+++ b/main.js
@@ -120,11 +120,11 @@ function cmd_test(msg, args) {
 		msg.reply('ich mache gerade eine Pause.');
 		console.log('Dies ist ein Test: Pausiert!');
 	}
+}
 
 function cmd_seite(msg, args) {
 	msg.channel.send('https://minecraft-de.gamepedia.com/' + args.join('_'));
 }
-	}
 
 function cmd_technik(msg, args) {
 	msg.channel.send('https://minecraft-technik.gamepedia.com/' + args.join('_'));
@@ -543,7 +543,7 @@ client.on('message', msg => {
 			} else {
 				var title = cont.split(' ')[1] + (args.length ? '_' : '') + args.join('_');
 				
-				if ( title.contains( '#' ) ) channel.send( 'https://minecraft-de.gamepedia.com/' + title );
+				if ( title.indexOf( '#' ) != -1 ) channel.send( 'https://minecraft-de.gamepedia.com/' + title );
 				else {
 					var hourglass;
 					msg.react('⏳').then( function( reaction ) {

--- a/main.js
+++ b/main.js
@@ -59,7 +59,7 @@ function cmd_help(msg, args) {
 		var cmdlist = ''
 		for ( var i = 0; i < cmds.length; i++ ) {
 			if ( cmds[i].split(' ')[0].equals( args[0].toLowerCase() ) && !cmds[i].unsearchable ) {
-				cmdlist += '🔹 `!wiki ' + cmds[i].cmd + '\n\t' + cmds[i].desc + '\n';
+				cmdlist += '🔹 `!wiki ' + cmds[i].cmd + '`\n\t' + cmds[i].desc + '\n';
 			}
 		}
 		
@@ -548,7 +548,6 @@ client.on('message', msg => {
 					var hourglass;
 					msg.react('⏳').then( function( reaction ) {
 						hourglass = reaction;
-					} ).catch( console.log ).finally( function() {
 						request( {
 							uri: 'https://minecraft-de.gamepedia.com/api.php?action=query&format=json&list=search&srsearch=' + title + '&srlimit=1',
 							json: true

--- a/main.js
+++ b/main.js
@@ -277,7 +277,32 @@ var befehle = {
 					'/enchant <Selektor> <Verzauberungs-ID> [<Stufe>]'
 				],
 	'execute':		[
-					'/* So kompliziert, diesen Befehl verstehe ich leider noch nicht! */'
+					'/execute align <Achsen> <execute-Unterbefehl>',
+					'/execute anchored (eyes|feet) <execute-Unterbefehl>',
+					'/execute as <Objekt> <execute-Unterbefehl>',
+					'/execute at <Objekt> <execute-Unterbefehl>',
+					'/execute facing <Koordinaten> <execute-Unterbefehl>',
+					'/execute facing entity <Objekt> <execute-Unterbefehl>',
+					'/execute if block <Koordinaten> <Block> <execute-Unterbefehl>',
+					'/execute if blocks <von-Koordinaten> <bis-Koordinaten> <Vergleichskoordinaten> <Block> <execute-Unterbefehl>',
+					'/execute if entity <Objekt> <execute-Unterbefehl>',
+					'/execute if score <Objekt> <Ziel> (<|<=|=|>|>=) <Objekt> <Ziel> <execute-Unterbefehl>',
+					'/execute if score <Objekt> <Ziel> matches <Bereich> <execute-Unterbefehl>',
+					'/execute in (overworld|the_end|the_nether) <execute-Unterbefehl>',
+					'/execute positioned <Koordinaten> <execute-Unterbefehl>',
+					'/execute positioned as <Objekt> <execute-Unterbefehl>',
+					'/execute rotated <Rotation> <execute-Unterbefehl>',
+					'/execute rotated as <Objekt> <execute-Unterbefehl>',
+					'/execute run <Befehl>',
+					'/execute store (result|success) block <Koordinaten> <Pfad> <Typ> <Skalierung> <execute-Unterbefehl>',
+					'/execute store (result|success) bossbar <Datenwert> (max|value) <Pfad> <Typ> <Skalierung> <execute-Unterbefehl>',
+					'/execute store (result|success) entity <Objekt> <Pfad> <Typ> <Skalierung> <execute-Unterbefehl>',
+					'/execute store (result|success) score <Objekt> <Ziel> <execute-Unterbefehl>',
+					'/execute unless block <Koordinaten> <Block> <execute-Unterbefehl>',
+					'/execute unless blocks <von-Koordinaten> <bis-Koordinaten> <Vergleichskoordinaten> <Block> <execute-Unterbefehl>',
+					'/execute unless entity <Objekt> <execute-Unterbefehl>',
+					'/execute unless score <Objekt> <Ziel> (<|<=|=|>|>=) <Objekt> <Ziel> <execute-Unterbefehl>',
+					'/execute unless score <Objekt> <Ziel> matches <Bereich> <execute-Unterbefehl>'
 				],
 	'experience':		[
 					'/experience add <Selektor> <Menge>',

--- a/main.js
+++ b/main.js
@@ -40,9 +40,9 @@ function cmd_help(msg, args) {
 		{ cmd: 'befehl <Minecraft-Befehl>', desc: 'Ich antworte mit der Syntax des angegebenen Minecraft-Befehls und einem Link auf den Artikel zu diesem Befehl im Minecraft Wiki', hide: true },
 		{ cmd: 'command <Minecraft-Befehl>', desc: 'Ich antworte mit der Syntax des angegebenen Minecraft-Befehls und einem Link auf den Artikel zu diesem Befehl im Minecraft Wiki', hide: true },
 		{ cmd: 'cmd <Minecraft-Befehl>', desc: 'Ich antworte mit der Syntax des angegebenen Minecraft-Befehls und einem Link auf den Artikel zu diesem Befehl im Minecraft Wiki', hide: true },
-		{ cmd: 'hilfe', 'Liste alle Befehle auf' },
+		{ cmd: 'hilfe', desc: 'Liste alle Befehle auf' },
 		{ cmd: 'hilfe [<Befehl>]', desc: 'Frage mich, wie ein Befehl funktioniert' },
-		{ cmd: 'help', 'Liste alle Befehle auf', hide: true },
+		{ cmd: 'help', desc: 'Liste alle Befehle auf', hide: true },
 		{ cmd: 'help [<Befehl>]', desc: 'Frage mich, wie ein Befehl funktioniert', hide: true },
 		{ cmd: 'test', desc: 'Wenn ich gerade aktiv bin, werde ich antworten! Sonst nicht.' },
 		{ cmd: 'seite <Seitenname>', desc: 'Ich antworte mit einem Link zu der angegebenen Seite im Minecraft Wiki' },
@@ -51,7 +51,7 @@ function cmd_help(msg, args) {
 		{ cmd: 'en <Seitenname>', desc: 'Ich antworte mit einem Link zu der angegebenen Seite im englischen Minecraft Wiki' },
 		{ cmd: 'uwmc <Seitenname>', desc: 'Ich antworte mit einem Link zu der angegebenen Seite im Unlimitedworld-Forum' },
 		{ cmd: 'invite', desc: 'Ich antworte mit dem Invite-Link für diesen Server' },
-		{ cmd: 'suche <Suchbegriff>', desc: 'Ich antworte mit einem Link auf die Suchseite zu diesem Begriff im Minecraft Wiki.' }
+		{ cmd: 'suche <Suchbegriff>', desc: 'Ich antworte mit einem Link auf die Suchseite zu diesem Begriff im Minecraft Wiki.' },
 		{ cmd: 'search <Suchbegriff>', desc: 'Ich antworte mit einem Link auf die Suchseite zu diesem Begriff im Minecraft Wiki.', hide: true }
 	]
 	


### PR DESCRIPTION
Full list of changes:
* The main command `!wiki <article name>` now searches for existing articles matching the arguments. For example `!wiki Elefant` will now link to the top search result https://minecraft-de.gamepedia.com/Modifikation/Hexxit – this is not always very precise, but at least it doesn't point users to non-existing pages. If the `<article name>` argument hotlinks to a section (using `#`) or if something goes wrong during the search process, the command will fall back to the previous behaviour. Due to the delay of searching for articles, the bot will react with an hourglass emoji until it has replied.
* The previous way the main command worked now is available as `!wiki seite` (alias: `!wiki page`)
* Added `!wiki hilfe` and `!wiki hilfe <command>` for bot commands (alias: `!wiki help`)
* The `!wiki /<command>` now won't accept invalid commands anymore and now shows the correct documentation for alias commands (for example, it shows `/tell` in its message if you use `!wiki /tell` instead of `/msg`). Also, it has three new aliases: `!wiki befehl <command>`, `!wiki command <command>` and `!wiki cmd <command>`, because why not.
* `!wiki say` is now available for all admins and will no longer post a link to the wiki if used by a normal user, but react with ❌ instead.
* Commands are case-insensitive now. `!WIKI TEST` now works, just like `!WiKi TeSt` and `!wiki test`.

To do:
* The bot should check whether the page specified with `!wiki <page>` exists before starting to search. Also, it would be nice if it could automatically resolve redirects.
* `!wiki pause` should work for all admins as well. `!wiki stop` and `!wiki pause` should behave like `!wiki say` currently does.
* Maybe the bot could delete the message that called it and then mention the user that called it in its message, to save some vertical space.